### PR TITLE
pidfile check

### DIFF
--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -40,8 +40,16 @@ module HAProxyCTL
     end
 
     def pidfile
-      config.match /pidfile \s*([^\s]*)/
-      @pidfile = $1 || raise("Expecting 'pidfile <pid_file_path>' in #{config_path}")
+      if config.match(/pidfile \s*([^\s]*)/)
+        @pidfile = $1
+      else
+        std_pid = "/var/run/haproxy.pid"
+        if File.exists?(std_pid)
+          @pidfile = std_pid
+        else
+          raise("Expecting 'pidfile <pid_file_path>' in #{config_path} or a pid file in #{std_pid}")
+        end
+      end
     end
 
     # @return [String, nil] Returns the PID of HAProxy as a string, if running. Nil otherwise.


### PR DESCRIPTION
The idea is to test `/var/run/haproxy.pid` if no `pidfile`-directive is found in the `haproxy.cfg`. 

I think this is safe to assume since `pidfile` is an optional setting and defaults to `/var/run`. If the pid is not found, it still raises your exception.

Btw – is there a requirement for a minimum version of haproxy?
