### PR TITLE
Terminate the unix socket command with a semicolon instead of a line feed

### DIFF
--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -54,7 +54,7 @@ module HAProxyCTL
     begin 
       ctl=UNIXSocket.open(socket)
       if (ctl)
-        ctl.puts "#{command}"
+        ctl.write "#{command};"
       else
         puts "cannot talk to #{socket}"
       end


### PR DESCRIPTION
This fixed intermittent Errno::ECONNRESET errors we were getting.

Other projects have noticed this too, see
https://github.com/tpett/hastats/commit/a6b6d35

Ref: http://cbonte.github.com/haproxy-dconv/configuration-1.4.html#9.2
