### PR TITLE
Account for multiple spaces between "stats" and "socket"

### DIFF
--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -38,7 +38,7 @@ module HAProxyCTL
 
     def socket
       @socket ||= begin
-        config.match /stats socket \s*([^\s]*)/
+        config.match /stats\s*socket \s*([^\s]*)/
         $1 || raise("Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
       end
     end


### PR DESCRIPTION
It seems valid to have a multiple spaces between "stats" and "socket" in the config, so now it's accounted for
