### PR TITLE
do not ship embedded rhapr library into gem release

### DIFF
--- a/haproxyctl.gemspec
+++ b/haproxyctl.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |gem|
   gem.rubyforge_project = "haproxyctl"
   gem.license       = "MIT"
   gem.files         = `git ls-files`.split($\)
+  gem.files.reject! { |fn| fn.include? "rhapr" }
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "haproxyctl"


### PR DESCRIPTION
This patch excludes the embedded rhapr library in the gem release. It's needed for Debian packaging. 

After applying that patch, could you please release a new version of haproxy on rubygems.org?

Thanks!
