### PR TITLE
Bumped to 1.4.0, added ability to deal with nbproc > 1

### DIFF
--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -32,7 +32,7 @@ begin
   case argument
   when 'start'
     if pidof
-      fail("haproxy is already running on pid #{pidof}!")
+      fail("haproxy is already running on pid(s) #{pidof.join(', ')}!")
     else
       start
     end
@@ -61,8 +61,11 @@ begin
     end
   when 'status'
     if  pidof
-      puts "haproxy is running on pid #{pidof}.\nthese ports are used and guys are connected:"
-      system("lsof -ln -i |awk \'$2 ~ /#{pidof}/ {print $8\" \"$9}\'")
+      puts "haproxy is running on pid(s) #{pidof.join(', ')}.\nthese ports are used and guys are connected:"
+      pidof.each do |pid|
+        puts "Showing lsof for PID: #{pid}"
+        system("lsof -ln -i |awk \'$2 ~ /#{pid}/ {print $8\" \"$9}\'")  
+      end
     else
       puts 'haproxy is not running'
     end
@@ -77,26 +80,27 @@ begin
       exit(2)
     end
   when 'cloudkick'
-    if  pidof
-      puts 'status ok haproxy is running'
-      conn = `lsof -ln -i |grep -c #{pidof}`.chomp.to_i
-      # removes the listener
-      conn = conn - 1
-      puts "metric connections int #{conn}"
-      status = unixsock('show stat')
-      status.each do |line|
-        line = line.split(',')
-        if line[0] !~ /^#/
-          host = "#{line[0]}_#{line[1]}"
-          puts "metric #{host}_request_rate int #{line[47]}" if line[47].to_i > 0
-          puts "metric #{host}_total_requests gauge #{line[49]}" if line[49].to_i > 0
-          puts "metric #{host}_health_check_duration int #{line[35]}" if line[35].to_i > 0
-          puts "metric ${host}_current_queue int #{line[3]}" if line[3].to_i > 0
-        end
-      end
-    else
-      puts 'status err haproxy is not running!'
-    end
+    puts 'Not supported, need to refactor after pidof changes.'
+    # if  pidof
+    #   puts 'status ok haproxy is running'
+    #   conn = `lsof -ln -i |grep -c #{pidof}`.chomp.to_i
+    #   # removes the listener
+    #   conn = conn - 1
+    #   puts "metric connections int #{conn}"
+    #   status = unixsock('show stat')
+    #   status.each do |line|
+    #     line = line.split(',')
+    #     if line[0] !~ /^#/
+    #       host = "#{line[0]}_#{line[1]}"
+    #       puts "metric #{host}_request_rate int #{line[47]}" if line[47].to_i > 0
+    #       puts "metric #{host}_total_requests gauge #{line[49]}" if line[49].to_i > 0
+    #       puts "metric #{host}_health_check_duration int #{line[35]}" if line[35].to_i > 0
+    #       puts "metric ${host}_current_queue int #{line[3]}" if line[3].to_i > 0
+    #     end
+    #   end
+    # else
+    #   puts 'status err haproxy is not running!'
+    # end
   when 'show health'
     status = unixsock('show stat')
     status.each do |line|

--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -8,9 +8,9 @@ module HAProxyCTL
   def start
     puts 'starting haproxy...'
     system("#{exec} -f #{config_path} -D -p #{pidfile}")
-    newpid = check_running
-    if newpid =~ /^\d+$/
-      puts "haproxy is running on pid #{newpid}"
+    newpids = check_running
+    if newpids.all? {|newpid| newpid =~ /^\d+$/} 
+      puts "haproxy is running on pid #{newpids.join(', ')}"
       return true
     else
       puts 'error. haproxy did not start!'
@@ -18,30 +18,30 @@ module HAProxyCTL
     end
   end
 
-  def stop(pid)
-    if pid
-      puts "stopping haproxy on pid #{pid}..."
-      system("kill #{pid}") || system("kill -9 #{pid}")
+  def stop(pids)
+    if pids
+      puts "stopping haproxy on pids #{pids.join(', ')}..."
+      pids.each { |pid| system("kill #{pid}") || system("kill -9 #{pid}") }
       puts '... stopped'
     else
       puts 'haproxy is not running!'
     end
   end
 
-  def reload(pid)
-    if pid
-      puts "gracefully stopping connections on pid #{pid}..."
-      system("#{exec} -f #{config_path} -sf #{pid}")
-      puts "checking if connections still alive on #{pid}..."
-      nowpid = check_running
-      while  pid == nowpid
-        puts "still haven't killed old pid.
+  def reload(pids)
+    if pids
+      puts "gracefully stopping connections on pids #{pids.join(', ')}..."
+      pids.each { |pid| system("#{exec} -f #{config_path} -sf #{pid}") }
+      puts "checking if connections still alive on #{pids.join(', ')}..."
+      nowpids = check_running
+      while pids == nowpids
+        puts "still haven't killed old pids.
                             waiting 2s for existing connections to die...
                             (ctrl+c to stop this check)"
         sleep 2
-        nowpid = check_running || 0
+        nowpids = check_running || 0
       end
-      puts "reloaded haproxy on pid #{nowpid}"
+      puts "reloaded haproxy on pids #{nowpids.join(', ')}"
     else
       puts 'haproxy is not running!'
     end

--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -31,7 +31,7 @@ module HAProxyCTL
   def reload(pids)
     if pids
       puts "gracefully stopping connections on pids #{pids.join(', ')}..."
-      pids.each { |pid| system("#{exec} -f #{config_path} -sf #{pid}") }
+      system("#{exec} -D -f #{config_path} -p #{pidfile} -sf $(cat #{pidfile})")
       puts "checking if connections still alive on #{pids.join(', ')}..."
       nowpids = check_running
       while pids == nowpids

--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -64,7 +64,7 @@ module HAProxyCTL
       end
 
       # verify these pid(s) exists and are haproxy
-      if pids.all? { |pid| pid =~ /^\d+$/ and `ps -p #{pid} -o cmd=` =~ /#{exec}/ }
+      if pids and pids.all? { |pid| pid =~ /^\d+$/ and `ps -p #{pid} -o cmd=` =~ /#{exec}/ }
         return pids
       end
     end

--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -56,16 +56,16 @@ module HAProxyCTL
       end
     end
 
-    # @return [String, nil] Returns the PID of HAProxy as a string, if running. Nil otherwise.
+    # @return [Array, nil] Returns the PIDs of HAProxy as an Array, if running. Nil otherwise.
     def check_running
       if File.exists?(pidfile)
         pid = File.read(pidfile)
-        pid.strip!
+        pids = pid.strip.split("\n")
       end
 
-      # verify this pid exists and is haproxy
-      if pid =~ /^\d+$/ and `ps -p #{pid} -o cmd=` =~ /#{exec}/
-        return pid
+      # verify these pid(s) exists and are haproxy
+      if pids.all? { |pid| pid =~ /^\d+$/ and `ps -p #{pid} -o cmd=` =~ /#{exec}/ }
+        return pids
       end
     end
     alias_method :pidof, :check_running

--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -39,7 +39,7 @@ module HAProxyCTL
     def nbproc 
       @nbproc ||= begin
         config.match /nbproc \s*(\d*)\s*/
-        Regexp.last_match[1] || 1
+        Regexp.last_match[1].to_i || 1
       end
     end
 
@@ -53,6 +53,7 @@ module HAProxyCTL
           config.match /stats\s+socket \s*([^\s]*) \s*.*process \s*1[\d^]?/
         else
           config.match /stats\s+socket \s*([^\s]*)/
+        end
         Regexp.last_match[1] || fail("Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
       end
     end

--- a/lib/haproxyctl/version.rb
+++ b/lib/haproxyctl/version.rb
@@ -1,3 +1,3 @@
 module HAProxyCTL
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/lib/haproxyctl/version.rb
+++ b/lib/haproxyctl/version.rb
@@ -1,3 +1,3 @@
 module HAProxyCTL
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/lib/haproxyctl/version.rb
+++ b/lib/haproxyctl/version.rb
@@ -1,3 +1,3 @@
 module HAProxyCTL
-  VERSION = '1.4.2'
+  VERSION = '1.4.3'
 end

--- a/lib/haproxyctl/version.rb
+++ b/lib/haproxyctl/version.rb
@@ -1,3 +1,3 @@
 module HAProxyCTL
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end


### PR DESCRIPTION
This still needs some work (i.e. fixing cloudkick, some cleanup), but it seems to be working for me.  To clarify what this is fixing, using nbproc > 1 in your haproxy.cfg will result in a pid file that has multiple pids.  Previous code expected a single line pid file.

Could use some assistance fixing cloudkick as I'm not sure what it's doing.  Let me know if you'd like me to clean up anything else.
