### PR TITLE
Fix issues when nbproc is not present in haproxy.cfg.

### DIFF
--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -38,8 +38,11 @@ module HAProxyCTL
 
     def nbproc 
       @nbproc ||= begin
-        config.match /nbproc \s*(\d*)\s*/
-        Regexp.last_match[1].to_i || 1
+        if config.match(/nbproc \s*(\d*)\s*/)
+          Regexp.last_match[1].to_i
+        else
+          1
+        end
       end
     end
 


### PR DESCRIPTION
Prevents this error: ../lib/haproxyctl/environment.rb:42:in []' for nil:NilClass (NoMethodError)
from /usr/local/sbin/../lib/haproxyctl/environment.rb:52:in unixsock'
from ./haproxyctl:105
