### PR TITLE
Fix deprecated code warnings

### DIFF
--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -114,7 +114,7 @@ begin
       printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
     end
   when /disable all EXCEPT (.+)/
-    servername = Regexp.last_match[ 1]
+    servername = Regexp.last_match(1)
     status = unixsock('show stat')
     backend = status.grep(/#{servername}/)
     backend.each do |line|
@@ -127,7 +127,7 @@ begin
       end
     end
   when /disable all (.+)/
-    servername = Regexp.last_match[ 1]
+    servername = Regexp.last_match(1)
     status = unixsock('show stat')
     status.each do |line|
       data = line.split(',')
@@ -136,7 +136,7 @@ begin
       end
     end
   when /enable all EXCEPT (.+)/
-    servername = Regexp.last_match[ 1]
+    servername = Regexp.last_match(1)
     status = unixsock('show stat')
     backend = status.grep(/#{servername}/)
     backend.each do |line|
@@ -149,7 +149,7 @@ begin
       end
     end
   when /show stat (.+)/
-    fieldnames = Regexp.last_match[ 1]
+    fieldnames = Regexp.last_match(1)
     status = unixsock('show stat')
     indices = fieldnames.split(' ').map do |name|
       status.first.split(',').index(name) || begin
@@ -164,7 +164,7 @@ begin
       puts (row[0...2] + filtered).compact.join(',')
     end
   when /enable all (.+)/
-    servername = Regexp.last_match[ 1]
+    servername = Regexp.last_match(1)
     status = unixsock('show stat')
     status.each do |line|
       data = line.split(',')

--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -39,7 +39,7 @@ module HAProxyCTL
     def nbproc 
       @nbproc ||= begin
         config.match /nbproc \s*(\d*)\s*/
-        Regexp.last_match[1].to_i || 1
+        Regexp.last_match(1).to_i || 1
       end
     end
 
@@ -54,13 +54,13 @@ module HAProxyCTL
         else
           config.match /stats\s+socket \s*([^\s]*)/
         end
-        Regexp.last_match[1] || fail("Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
+        Regexp.last_match(1) || fail("Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
       end
     end
 
     def pidfile
       if config.match(/pidfile \s*([^\s]*)/)
-        @pidfile = Regexp.last_match[1]
+        @pidfile = Regexp.last_match(1)
       else
         std_pid = '/var/run/haproxy.pid'
         if File.exists?(std_pid)

--- a/rhapr/lib/rhapr/environment.rb
+++ b/rhapr/lib/rhapr/environment.rb
@@ -71,7 +71,7 @@ module Rhapr
     def socket_path
       @socket_path  ||= begin
                           config.match /stats\s+socket\s+([^\s]*)/
-                          Regexp.last_match[1] || fail(RuntimeError.new "Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
+                          Regexp.last_match(1) || fail(RuntimeError.new "Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
                         end
     end
 
@@ -81,7 +81,7 @@ module Rhapr
     def pid
       @pid  ||= begin
                   config.match /pidfile ([^\s]*)/
-                  Regexp.last_match[1] || '/var/run/haproxy.pid'
+                  Regexp.last_match(1) || '/var/run/haproxy.pid'
                 end
     end
 

--- a/rhapr/lib/rhapr/interface.rb
+++ b/rhapr/lib/rhapr/interface.rb
@@ -68,7 +68,7 @@ module Rhapr
       resp = send "get weight #{backend}/#{server}"
 
       resp.match /([[:digit:]]+) \(initial ([[:digit:]]+)\)/
-      weight, initial = Regexp.last_match[1], Regexp.last_match[2]
+      weight, initial = Regexp.last_match(1), Regexp.last_match(2)
 
       return [weight.to_i, initial.to_i] if weight and initial
 

--- a/rhapr/spec/rhapr/environment_spec.rb
+++ b/rhapr/spec/rhapr/environment_spec.rb
@@ -55,7 +55,7 @@ describe Rhapr::Environment do
     end
 
     it 'should read and return the contents of a file' do
-      File.should_receive(:read).and_return { "I can haz cfg ?\n" }
+      File.should_receive(:read).and_return("I can haz cfg ?\n")
 
       @env_test.config.should == "I can haz cfg ?\n"
     end
@@ -98,13 +98,13 @@ describe Rhapr::Environment do
 
   describe '#socket_path' do
     it 'should parse out the io socket from the config file' do
-      @env_test.should_receive(:config).and_return { config_for(:basic_haproxy) }
+      @env_test.should_receive(:config).and_return(config_for(:basic_haproxy))
 
       @env_test.socket_path.should == '/tmp/haproxy'
     end
 
     it 'should raise an error if it cannot derive an io socket from the config file' do
-      @env_test.should_receive(:config).and_return { config_for(:crappy_haproxy) }
+      @env_test.should_receive(:config).and_return(config_for(:crappy_haproxy))
 
       lambda do
         @env_test.socket_path
@@ -114,13 +114,13 @@ describe Rhapr::Environment do
 
   describe '#pid' do
     it 'should parse out the pidfile from the config file' do
-      @env_test.should_receive(:config).and_return { config_for(:pid_test_haproxy) }
+      @env_test.should_receive(:config).and_return(config_for(:pid_test_haproxy))
 
       @env_test.pid.should == '/some/other/run/haproxy.pid'
     end
 
     it 'should return a default path if it cannot derive an io socket from the config file' do
-      @env_test.should_receive(:config).and_return { config_for(:crappy_haproxy) }
+      @env_test.should_receive(:config).and_return(config_for(:crappy_haproxy))
 
       @env_test.pid.should == '/var/run/haproxy.pid'
     end

--- a/rhapr/spec/rhapr/environment_spec.rb
+++ b/rhapr/spec/rhapr/environment_spec.rb
@@ -127,6 +127,6 @@ describe Rhapr::Environment do
   end
 
   describe '#check_running, #pidof' do
-    pending 'TBD'
+    skip 'TBD'
   end
 end

--- a/rhapr/spec/rhapr/environment_spec.rb
+++ b/rhapr/spec/rhapr/environment_spec.rb
@@ -20,14 +20,14 @@ describe Rhapr::Environment do
     end
 
     it 'should go down a list of pre-defined file names' do
-      File.stub!(:exists?).and_return(false)
+      File.stub(:exists?).and_return(false)
       File.should_receive(:exists?).with('/etc/haproxy.cfg').and_return(true)
 
       @env_test.config_path.should == '/etc/haproxy.cfg'
     end
 
     it 'should select the first configuration found, from the pre-defined list' do
-      File.stub!(:exists?).and_return(false)
+      File.stub(:exists?).and_return(false)
       File.should_receive(:exists?).with('/etc/haproxy/haproxy.cfg').and_return(true)
       File.should_receive(:exists?).with('/etc/haproxy.cfg').and_return(true)
 
@@ -35,14 +35,14 @@ describe Rhapr::Environment do
     end
 
     it 'should be nil if config files do not exist and $HAPROXY_CONFIG is not set' do
-      File.stub!(:exists?).and_return(false)
+      File.stub(:exists?).and_return(false)
       @env_test.config_path.should be_nil
     end
   end
 
   describe '#config' do
     before(:each) do
-      File.stub!(:exists?).and_return(false)
+      File.stub(:exists?).and_return(false)
       File.should_receive(:exists?).with('/etc/haproxy.cfg').and_return(true)
     end
 

--- a/rhapr/spec/rhapr/interface_spec.rb
+++ b/rhapr/spec/rhapr/interface_spec.rb
@@ -22,7 +22,7 @@ describe Rhapr::Interface do
     it 'should send the "clear counters" message to HAProxy' do
       subject.should_receive(:send).with('clear counters').and_return("\n")
 
-      subject.clear_counters.should be_true
+      subject.clear_counters.should be true
     end
   end
 


### PR DESCRIPTION
Warnings about stuff that is deprecated - hopefully correct. 
Some ruby guru can probably confirm. 

I couldn't catch this deprecation error when running the tests for rhapr:

```
Using `s` as a shortcut for the DocumentationFormatter is deprecated. Use `d`, `doc`, or `documentation` instead.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```

as providing `config.raise_errors_for_deprecations!` in spec_helper.rb for `rhapr` didn't help. 
