### PR TITLE
Support communicating with multiple admin sockets when nbprocs>1

### DIFF
--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -114,7 +114,7 @@ begin
       printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
     end
   when /disable all EXCEPT (.+)/
-    servername = Regexp.last_match[ 1]
+    servername = Regexp.last_match(1)
     status = unixsock('show stat')
     backend = status.grep(/#{servername}/)
     backend.each do |line|
@@ -127,7 +127,7 @@ begin
       end
     end
   when /disable all (.+)/
-    servername = Regexp.last_match[ 1]
+    servername = Regexp.last_match(1)
     status = unixsock('show stat')
     status.each do |line|
       data = line.split(',')
@@ -136,7 +136,7 @@ begin
       end
     end
   when /enable all EXCEPT (.+)/
-    servername = Regexp.last_match[ 1]
+    servername = Regexp.last_match(1)
     status = unixsock('show stat')
     backend = status.grep(/#{servername}/)
     backend.each do |line|
@@ -149,7 +149,7 @@ begin
       end
     end
   when /show stat (.+)/
-    fieldnames = Regexp.last_match[ 1]
+    fieldnames = Regexp.last_match(1)
     status = unixsock('show stat')
     indices = fieldnames.split(' ').map do |name|
       status.first.split(',').index(name) || begin
@@ -164,7 +164,7 @@ begin
       puts (row[0...2] + filtered).compact.join(',')
     end
   when /enable all (.+)/
-    servername = Regexp.last_match[ 1]
+    servername = Regexp.last_match(1)
     status = unixsock('show stat')
     status.each do |line|
       data = line.split(',')

--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -45,6 +45,15 @@ end
 # Strip of the -p <process> argument as argument is passed to unix socket if not defined below
 argument = argument.gsub(/-p\s*([^\[\s\]]*)/, '')
 
+# For all data fetching logic below, we need to strip ^\d+:\s if dsh_output
+dsh_output ||= begin
+            if process == 0
+              1
+            else
+              0
+            end
+          end
+
 begin
   case argument
   when 'start'
@@ -122,13 +131,15 @@ begin
     status = unixsock(process, 'show stat')
     status.each do |line|
       data = line.split(',')
-      printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
+      dsh_data0 ||= data[0].sub(/\d+:\s/, '') if dsh_output || data[0]
+      printf "%-30s %-30s %-7s %3s\n", dsh_data0, data[1], data[17], data[18]
     end
   when /show backend(s?)/
     status = unixsock(process, 'show stat').grep(/BACKEND/)
     status.each do |line|
       data = line.split(',')
-      printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
+      dsh_data0 ||= data[0].sub(/\d+:\s/, '') if dsh_output || data[0]
+      printf "%-30s %-30s %-7s %3s\n", dsh_data0, data[1], data[17], data[18]
     end
   when /disable all EXCEPT (.+)/
     servername = Regexp.last_match(1)
@@ -138,8 +149,9 @@ begin
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
-        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] == 'UP')
-          unixsock(process, "disable server #{data[0]}/#{data[1]}")
+        dsh_data0 ||= data[0].sub(/\d+:\s/, '') if dsh_output || data[0]
+        if  (dsh_data0 == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] == 'UP')
+          unixsock(process, "disable server #{dsh_data0}/#{data[1]}")
         end
       end
     end
@@ -149,7 +161,8 @@ begin
     status.each do |line|
       data = line.split(',')
       if  ( data[1] == servername) && ( data[17] == 'UP')
-        unixsock(process, "disable server #{data[0]}/#{servername}")
+        dsh_data0 ||= data[0].sub(/\d+:\s/, '') if dsh_output || data[0]
+        unixsock(process, "disable server #{dsh_data0}/#{servername}")
       end
     end
   when /enable all EXCEPT (.+)/
@@ -160,8 +173,9 @@ begin
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
-        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] =~ /Down|MAINT/i)
-          unixsock(process, "enable server #{data[0]}/#{data[1]}")
+        dsh_data0 ||= data[0].sub(/\d+:\s/, '') if dsh_output || data[0]
+        if  (dsh_data0 == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] =~ /Down|MAINT/i)
+          unixsock(process, "enable server #{dsh_data0}/#{data[1]}")
         end
       end
     end
@@ -186,7 +200,8 @@ begin
     status.each do |line|
       data = line.split(',')
       if  ( data[1] == servername) && ( data[17] =~ /Down|MAINT/i)
-        unixsock(process, "enable server #{data[0]}/#{servername}")
+        dsh_data0 ||= data[0].sub(/\d+:\s/, '') if dsh_output || data[0]
+        unixsock(process, "enable server #{dsh_data0}/#{servername}")
       end
     end
   when 'version'

--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -131,15 +131,13 @@ begin
     status = unixsock(process, 'show stat')
     status.each do |line|
       data = line.split(',')
-      dsh_data0 ||= data[0].sub(/\d+:\s/, '') if dsh_output || data[0]
-      printf "%-30s %-30s %-7s %3s\n", dsh_data0, data[1], data[17], data[18]
+      printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
     end
   when /show backend(s?)/
     status = unixsock(process, 'show stat').grep(/BACKEND/)
     status.each do |line|
       data = line.split(',')
-      dsh_data0 ||= data[0].sub(/\d+:\s/, '') if dsh_output || data[0]
-      printf "%-30s %-30s %-7s %3s\n", dsh_data0, data[1], data[17], data[18]
+      printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
     end
   when /disable all EXCEPT (.+)/
     servername = Regexp.last_match(1)

--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -28,6 +28,23 @@ end
 
 display_usage! if argument =~ /help/ || ARGV.length < 1
 
+
+process ||= argument.scan(/-p\s*([^\[\s\]]+)/).flatten
+
+if !process.empty?
+  process = process[0].to_i
+elsif process.empty?
+  if nbproc > 1
+    # Default to old behavior to use the first socket.
+    process = 1
+  else
+    # Default to unix socket not bound to a process id.
+    process = 0
+  end
+end
+# Strip of the -p <process> argument as argument is passed to unix socket if not defined below
+argument = argument.gsub(/-p\s*([^\[\s\]]*)/, '')
+
 begin
   case argument
   when 'start'
@@ -87,7 +104,7 @@ begin
     #   # removes the listener
     #   conn = conn - 1
     #   puts "metric connections int #{conn}"
-    #   status = unixsock('show stat')
+    #   status = unixsock(process, 'show stat')
     #   status.each do |line|
     #     line = line.split(',')
     #     if line[0] !~ /^#/
@@ -102,55 +119,55 @@ begin
     #   puts 'status err haproxy is not running!'
     # end
   when 'show health'
-    status = unixsock('show stat')
+    status = unixsock(process, 'show stat')
     status.each do |line|
       data = line.split(',')
       printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
     end
   when /show backend(s?)/
-    status = unixsock('show stat').grep(/BACKEND/)
+    status = unixsock(process, 'show stat').grep(/BACKEND/)
     status.each do |line|
       data = line.split(',')
       printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
     end
   when /disable all EXCEPT (.+)/
     servername = Regexp.last_match(1)
-    status = unixsock('show stat')
+    status = unixsock(process, 'show stat')
     backend = status.grep(/#{servername}/)
     backend.each do |line|
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
         if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] == 'UP')
-          unixsock("disable server #{data[0]}/#{data[1]}")
+          unixsock(process, "disable server #{data[0]}/#{data[1]}")
         end
       end
     end
   when /disable all (.+)/
     servername = Regexp.last_match(1)
-    status = unixsock('show stat')
+    status = unixsock(process, 'show stat')
     status.each do |line|
       data = line.split(',')
       if  ( data[1] == servername) && ( data[17] == 'UP')
-        unixsock("disable server #{data[0]}/#{servername}")
+        unixsock(process, "disable server #{data[0]}/#{servername}")
       end
     end
   when /enable all EXCEPT (.+)/
     servername = Regexp.last_match(1)
-    status = unixsock('show stat')
+    status = unixsock(process, 'show stat')
     backend = status.grep(/#{servername}/)
     backend.each do |line|
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
         if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] =~ /Down|MAINT/i)
-          unixsock("enable server #{data[0]}/#{data[1]}")
+          unixsock(process, "enable server #{data[0]}/#{data[1]}")
         end
       end
     end
   when /show stat (.+)/
     fieldnames = Regexp.last_match(1)
-    status = unixsock('show stat')
+    status = unixsock(process, 'show stat')
     indices = fieldnames.split(' ').map do |name|
       status.first.split(',').index(name) || begin
         $stderr.puts("no such field: #{name}")
@@ -165,17 +182,17 @@ begin
     end
   when /enable all (.+)/
     servername = Regexp.last_match(1)
-    status = unixsock('show stat')
+    status = unixsock(process, 'show stat')
     status.each do |line|
       data = line.split(',')
       if  ( data[1] == servername) && ( data[17] =~ /Down|MAINT/i)
-        unixsock("enable server #{data[0]}/#{servername}")
+        unixsock(process, "enable server #{data[0]}/#{servername}")
       end
     end
   when 'version'
     version
   else
-    puts unixsock(argument)
+    puts unixsock(process, argument)
   end
 rescue Errno::ENOENT => e
   STDERR.puts e

--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -43,7 +43,7 @@ elsif process.empty?
   end
 end
 # Strip of the -p <process> argument as argument is passed to unix socket if not defined below
-argument = argument.gsub(/-p\s*([^\[\s\]]*)/, '')
+argument = argument.gsub(/-p\s*([^\[\s\]]*)\s/, '')
 
 # For all data fetching logic below, we need to strip ^\d+:\s if dsh_output
 dsh_output ||= begin

--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -85,7 +85,7 @@ module HAProxyCTL
       if nbproc > 1
         # Only multiple socket execution prefixes lines with process id
         # - inspired from dsh.
-        sockets().each.sort.map{|k,v| execute(v, command).map { |line| "#{k}: #{line}" }}
+        sockets().each.sort.map{|k,v| execute(v, command).map { |line| "#{k}: #{line}" }}.flatten
       else
         execute(sockets()[0], command)
       end

--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -82,7 +82,13 @@ module HAProxyCTL
     end
 
     if process == 0
-      sockets().each.sort.map{|k,v| execute(v, command).map { |line| "#{k}: #{line}" }}
+      if nbproc > 1
+        # Only multiple socket execution prefixes lines with process id
+        # - inspired from dsh.
+        sockets().each.sort.map{|k,v| execute(v, command).map { |line| "#{k}: #{line}" }}
+      else
+        execute(sockets()[0], command)
+      end
     else
       if !sockets().has_key?(process)
         fail(RuntimeError.new "Could not find a stats socket with process #{process} in #{config_path}")

--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -47,36 +47,49 @@ module HAProxyCTL
     end
   end
 
-  def unixsock(command)
-    output = []
-    runs = 0
+  def unixsock(process, command)
 
-    begin
-      ctl = UNIXSocket.open(socket)
-      if ctl
-        ctl.write "#{command}\r\n"
-      else
-        puts "cannot talk to #{socket}"
+    def execute(socket, command)
+      output = []
+      runs = 0
+
+      begin
+        ctl = UNIXSocket.open(socket)
+        if ctl
+          ctl.write "#{command}\r\n"
+        else
+          puts "cannot talk to #{socket}"
+        end
+      rescue Errno::EPIPE
+        ctl.close
+        sleep 0.5
+        runs += 1
+        if  runs < 4
+          retry
+        else
+          puts "the unix socket at #{socket} closed before we could complete this request"
+          exit
+        end
       end
-    rescue Errno::EPIPE
+      while (line = ctl.gets)
+        unless  line =~ /Unknown command/
+          output << line
+        end
+      end
       ctl.close
-      sleep 0.5
-      runs += 1
-      if  runs < 4
-        retry
-      else
-        puts "the unix socket at #{socket} closed before we could complete this request"
-        exit
-      end
-    end
-    while (line = ctl.gets)
-      unless  line =~ /Unknown command/
-        output << line
-      end
-    end
-    ctl.close
 
-    output
+      output
+    end
+
+    if process == 0
+      sockets().each.sort.map{|k,v| execute(v, command).map { |line| "#{k}: #{line}" }}
+    else
+      if !sockets().has_key?(process)
+        fail(RuntimeError.new "Could not find a stats socket with process #{process} in #{config_path}")
+      else
+        execute(sockets()[process], command)
+      end
+    end
   end
 
   def display_usage!

--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -39,7 +39,7 @@ module HAProxyCTL
     def nbproc 
       @nbproc ||= begin
         config.match /nbproc \s*(\d*)\s*/
-        Regexp.last_match[1].to_i || 1
+        Regexp.last_match(1).to_i || 1
       end
     end
 
@@ -54,13 +54,13 @@ module HAProxyCTL
         else
           config.match /stats\s+socket \s*([^\s]*)/
         end
-        Regexp.last_match[1] || fail("Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
+        Regexp.last_match(1) || fail("Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
       end
     end
 
     def pidfile
       if config.match(/pidfile \s*([^\s]*)/)
-        @pidfile = Regexp.last_match[1]
+        @pidfile = Regexp.last_match(1)
       else
         std_pid = '/var/run/haproxy.pid'
         if File.exists?(std_pid)

--- a/rhapr/lib/rhapr/environment.rb
+++ b/rhapr/lib/rhapr/environment.rb
@@ -71,7 +71,7 @@ module Rhapr
     def socket_path
       @socket_path  ||= begin
                           config.match /stats\s+socket\s+([^\s]*)/
-                          Regexp.last_match[1] || fail(RuntimeError.new "Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
+                          Regexp.last_match(1) || fail(RuntimeError.new "Expecting 'stats socket <UNIX_socket_path>' in #{config_path}")
                         end
     end
 
@@ -81,7 +81,7 @@ module Rhapr
     def pid
       @pid  ||= begin
                   config.match /pidfile ([^\s]*)/
-                  Regexp.last_match[1] || '/var/run/haproxy.pid'
+                  Regexp.last_match(1) || '/var/run/haproxy.pid'
                 end
     end
 

--- a/rhapr/lib/rhapr/interface.rb
+++ b/rhapr/lib/rhapr/interface.rb
@@ -68,7 +68,7 @@ module Rhapr
       resp = send "get weight #{backend}/#{server}"
 
       resp.match /([[:digit:]]+) \(initial ([[:digit:]]+)\)/
-      weight, initial = Regexp.last_match[1], Regexp.last_match[2]
+      weight, initial = Regexp.last_match(1), Regexp.last_match(2)
 
       return [weight.to_i, initial.to_i] if weight and initial
 

--- a/rhapr/lib/rhapr/interface.rb
+++ b/rhapr/lib/rhapr/interface.rb
@@ -7,10 +7,11 @@ module Rhapr
     EMPTY = "\n"
 
     # @param [String, #to_s] message The message to be sent to HAProxy
+    # @param [int] process id for retrieving correct stats socket
     # return [Array<String>] All of the output from HAProxy, read in.
     # @see Rhapr::Interface#write, Rhapr::Interface#read_full
-    def send(message)
-      sock = socket
+    def send(message, process=1)
+      sock = socket(process)
 
       write(sock, message)
       read_full(sock)

--- a/rhapr/spec/config_fixtures/nbprocs_haproxy.cfg
+++ b/rhapr/spec/config_fixtures/nbprocs_haproxy.cfg
@@ -1,0 +1,36 @@
+global
+    daemon
+    maxconn 1024
+    # quiet
+    pidfile /var/run/haproxy.pid
+    nbproc 2
+    stats socket /tmp/haproxy-1 level admin uid 501 process 4 group staff mode 0660
+    stats socket /tmp/haproxy-2 level admin uid 501 group staff mode 0660 process 5
+
+defaults
+    log global
+    mode http
+    option httplog
+    option dontlognull
+    stats enable
+    stats uri /proxystats     # and this guy for statistics
+    stats auth webreport:areallysecretsupersecurepassword
+    stats refresh 5s
+
+listen thrift :9090
+    mode    tcp
+    balance roundrobin
+    option  tcplog
+    option  redispatch
+    retries 3
+
+    contimeout  5000
+    clitimeout  40000
+    srvtimeout  7000
+
+    server thrift1 localhost:9091 maxconn 20 check inter 20000
+    server thrift2 localhost:9092 maxconn 20 check inter 20000
+    server thrift3 localhost:9093 maxconn 20 check inter 20000
+    server thrift4 localhost:9094 maxconn 20 check inter 20000
+    server thrift5 localhost:9095 maxconn 20 check inter 20000
+    server thrift6 localhost:9096 maxconn 20 check inter 20000

--- a/rhapr/spec/rhapr/environment_spec.rb
+++ b/rhapr/spec/rhapr/environment_spec.rb
@@ -55,7 +55,7 @@ describe Rhapr::Environment do
     end
 
     it 'should read and return the contents of a file' do
-      File.should_receive(:read).and_return { "I can haz cfg ?\n" }
+      File.should_receive(:read).and_return("I can haz cfg ?\n")
 
       @env_test.config.should == "I can haz cfg ?\n"
     end
@@ -98,13 +98,13 @@ describe Rhapr::Environment do
 
   describe '#socket_path' do
     it 'should parse out the io socket from the config file' do
-      @env_test.should_receive(:config).and_return { config_for(:basic_haproxy) }
+      @env_test.should_receive(:config).and_return(config_for(:basic_haproxy))
 
       @env_test.socket_path.should == '/tmp/haproxy'
     end
 
     it 'should raise an error if it cannot derive an io socket from the config file' do
-      @env_test.should_receive(:config).and_return { config_for(:crappy_haproxy) }
+      @env_test.should_receive(:config).and_return(config_for(:crappy_haproxy))
 
       lambda do
         @env_test.socket_path
@@ -114,13 +114,13 @@ describe Rhapr::Environment do
 
   describe '#pid' do
     it 'should parse out the pidfile from the config file' do
-      @env_test.should_receive(:config).and_return { config_for(:pid_test_haproxy) }
+      @env_test.should_receive(:config).and_return(config_for(:pid_test_haproxy))
 
       @env_test.pid.should == '/some/other/run/haproxy.pid'
     end
 
     it 'should return a default path if it cannot derive an io socket from the config file' do
-      @env_test.should_receive(:config).and_return { config_for(:crappy_haproxy) }
+      @env_test.should_receive(:config).and_return(config_for(:crappy_haproxy))
 
       @env_test.pid.should == '/var/run/haproxy.pid'
     end

--- a/rhapr/spec/rhapr/environment_spec.rb
+++ b/rhapr/spec/rhapr/environment_spec.rb
@@ -127,6 +127,6 @@ describe Rhapr::Environment do
   end
 
   describe '#check_running, #pidof' do
-    pending 'TBD'
+    skip 'TBD'
   end
 end

--- a/rhapr/spec/rhapr/environment_spec.rb
+++ b/rhapr/spec/rhapr/environment_spec.rb
@@ -20,14 +20,14 @@ describe Rhapr::Environment do
     end
 
     it 'should go down a list of pre-defined file names' do
-      File.stub!(:exists?).and_return(false)
+      File.stub(:exists?).and_return(false)
       File.should_receive(:exists?).with('/etc/haproxy.cfg').and_return(true)
 
       @env_test.config_path.should == '/etc/haproxy.cfg'
     end
 
     it 'should select the first configuration found, from the pre-defined list' do
-      File.stub!(:exists?).and_return(false)
+      File.stub(:exists?).and_return(false)
       File.should_receive(:exists?).with('/etc/haproxy/haproxy.cfg').and_return(true)
       File.should_receive(:exists?).with('/etc/haproxy.cfg').and_return(true)
 
@@ -35,14 +35,14 @@ describe Rhapr::Environment do
     end
 
     it 'should be nil if config files do not exist and $HAPROXY_CONFIG is not set' do
-      File.stub!(:exists?).and_return(false)
+      File.stub(:exists?).and_return(false)
       @env_test.config_path.should be_nil
     end
   end
 
   describe '#config' do
     before(:each) do
-      File.stub!(:exists?).and_return(false)
+      File.stub(:exists?).and_return(false)
       File.should_receive(:exists?).with('/etc/haproxy.cfg').and_return(true)
     end
 

--- a/rhapr/spec/rhapr/interface_spec.rb
+++ b/rhapr/spec/rhapr/interface_spec.rb
@@ -22,7 +22,7 @@ describe Rhapr::Interface do
     it 'should send the "clear counters" message to HAProxy' do
       subject.should_receive(:send).with('clear counters').and_return("\n")
 
-      subject.clear_counters.should be_true
+      subject.clear_counters.should be true
     end
   end
 


### PR DESCRIPTION
This is rebased on top of PR #29  

This code is provided as is with no guarantees. 

librhapr breaking changes:

rhapr interface has changed, `send(message)` is now `send(message, process=1)` so it can pass on which process id to try to look up for a socket. 

in rhapr environment module:
   `socket_path` is renamed to `socket_paths` and now returns an hash for socket paths , keyed on process id's.  It still throws an runtime exception if no socket is found. A future enhancement might be to let it return an empty hash and let the client code which uses the library figure out what to do if it doesn't find any admin sockets.
  `socket` now accepts an argument for the parameter process.

haproxyctl binary accepts the parameter `-p` where the argument has to be numeric identifier for the process id. if nbprocs > 1 , 0 means talking to every socket it finds.

Known bugs:
Regex doesn't skip #comments in file, so if you "redefine" the admin socket in a comment below the original comment, it will sadly overwrite it in the internal hash map. 

Example outputs:

with nbprocs > 1

```
[root@a7504fbfa532 source]#  ./bin/haproxyctl -p1 show pools
Dumping pools usage. Use SIGQUIT to flush them.
  - Pool pipe (32 bytes) : 5 allocated (160 bytes), 5 used, 3 users [SHARED]
  - Pool capture (64 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
  - Pool channel (80 bytes) : 2 allocated (160 bytes), 2 used, 1 users [SHARED]
  - Pool task (112 bytes) : 24 allocated (2688 bytes), 24 used, 1 users [SHARED]
  - Pool uniqueid (128 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
  - Pool connection (320 bytes) : 2 allocated (640 bytes), 2 used, 1 users [SHARED]
  - Pool hdr_idx (416 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
  - Pool session (864 bytes) : 1 allocated (864 bytes), 1 used, 1 users [SHARED]
  - Pool requri (1024 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
  - Pool buffer (16416 bytes) : 2 allocated (32832 bytes), 2 used, 1 users [SHARED]
Total: 10 pools, 37344 bytes allocated, 37344 used.

[root@a7504fbfa532 source]#  ./bin/haproxyctl -p0 show pools
1: Dumping pools usage. Use SIGQUIT to flush them.
1:   - Pool pipe (32 bytes) : 5 allocated (160 bytes), 5 used, 3 users [SHARED]
1:   - Pool capture (64 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
1:   - Pool channel (80 bytes) : 2 allocated (160 bytes), 2 used, 1 users [SHARED]
1:   - Pool task (112 bytes) : 24 allocated (2688 bytes), 24 used, 1 users [SHARED]
1:   - Pool uniqueid (128 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
1:   - Pool connection (320 bytes) : 2 allocated (640 bytes), 2 used, 1 users [SHARED]
1:   - Pool hdr_idx (416 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
1:   - Pool session (864 bytes) : 1 allocated (864 bytes), 1 used, 1 users [SHARED]
1:   - Pool requri (1024 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
1:   - Pool buffer (16416 bytes) : 2 allocated (32832 bytes), 2 used, 1 users [SHARED]
1: Total: 10 pools, 37344 bytes allocated, 37344 used.
1: 
2: Dumping pools usage. Use SIGQUIT to flush them.
2:   - Pool pipe (32 bytes) : 5 allocated (160 bytes), 5 used, 3 users [SHARED]
2:   - Pool capture (64 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
2:   - Pool channel (80 bytes) : 2 allocated (160 bytes), 2 used, 1 users [SHARED]
2:   - Pool task (112 bytes) : 24 allocated (2688 bytes), 24 used, 1 users [SHARED]
2:   - Pool uniqueid (128 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
2:   - Pool connection (320 bytes) : 2 allocated (640 bytes), 2 used, 1 users [SHARED]
2:   - Pool hdr_idx (416 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
2:   - Pool session (864 bytes) : 1 allocated (864 bytes), 1 used, 1 users [SHARED]
2:   - Pool requri (1024 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
2:   - Pool buffer (16416 bytes) : 2 allocated (32832 bytes), 2 used, 1 users [SHARED]
2: Total: 10 pools, 37344 bytes allocated, 37344 used.
2: 
3: Dumping pools usage. Use SIGQUIT to flush them.
3:   - Pool pipe (32 bytes) : 5 allocated (160 bytes), 5 used, 3 users [SHARED]
3:   - Pool capture (64 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
3:   - Pool channel (80 bytes) : 2 allocated (160 bytes), 2 used, 1 users [SHARED]
3:   - Pool task (112 bytes) : 24 allocated (2688 bytes), 24 used, 1 users [SHARED]
3:   - Pool uniqueid (128 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
3:   - Pool connection (320 bytes) : 2 allocated (640 bytes), 2 used, 1 users [SHARED]
3:   - Pool hdr_idx (416 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
3:   - Pool session (864 bytes) : 1 allocated (864 bytes), 1 used, 1 users [SHARED]
3:   - Pool requri (1024 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
3:   - Pool buffer (16416 bytes) : 2 allocated (32832 bytes), 2 used, 1 users [SHARED]
3: Total: 10 pools, 37344 bytes allocated, 37344 used.
3: 
4: Dumping pools usage. Use SIGQUIT to flush them.
4:   - Pool pipe (32 bytes) : 5 allocated (160 bytes), 5 used, 3 users [SHARED]
4:   - Pool capture (64 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
4:   - Pool channel (80 bytes) : 2 allocated (160 bytes), 2 used, 1 users [SHARED]
4:   - Pool task (112 bytes) : 24 allocated (2688 bytes), 24 used, 1 users [SHARED]
4:   - Pool uniqueid (128 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
4:   - Pool connection (320 bytes) : 2 allocated (640 bytes), 2 used, 1 users [SHARED]
4:   - Pool hdr_idx (416 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
4:   - Pool session (864 bytes) : 1 allocated (864 bytes), 1 used, 1 users [SHARED]
4:   - Pool requri (1024 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
4:   - Pool buffer (16416 bytes) : 2 allocated (32832 bytes), 2 used, 1 users [SHARED]
4: Total: 10 pools, 37344 bytes allocated, 37344 used.
4: 
5: Dumping pools usage. Use SIGQUIT to flush them.
5:   - Pool pipe (32 bytes) : 5 allocated (160 bytes), 5 used, 3 users [SHARED]
5:   - Pool capture (64 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
5:   - Pool channel (80 bytes) : 2 allocated (160 bytes), 2 used, 1 users [SHARED]
5:   - Pool task (112 bytes) : 24 allocated (2688 bytes), 24 used, 1 users [SHARED]
5:   - Pool uniqueid (128 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
5:   - Pool connection (320 bytes) : 2 allocated (640 bytes), 2 used, 1 users [SHARED]
5:   - Pool hdr_idx (416 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
5:   - Pool session (864 bytes) : 1 allocated (864 bytes), 1 used, 1 users [SHARED]
5:   - Pool requri (1024 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
5:   - Pool buffer (16416 bytes) : 2 allocated (32832 bytes), 2 used, 1 users [SHARED]
5: Total: 10 pools, 37344 bytes allocated, 37344 used.
5: 
6: Dumping pools usage. Use SIGQUIT to flush them.
6:   - Pool pipe (32 bytes) : 5 allocated (160 bytes), 5 used, 3 users [SHARED]
6:   - Pool capture (64 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
6:   - Pool channel (80 bytes) : 2 allocated (160 bytes), 2 used, 1 users [SHARED]
6:   - Pool task (112 bytes) : 24 allocated (2688 bytes), 24 used, 1 users [SHARED]
6:   - Pool uniqueid (128 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
6:   - Pool connection (320 bytes) : 2 allocated (640 bytes), 2 used, 1 users [SHARED]
6:   - Pool hdr_idx (416 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
6:   - Pool session (864 bytes) : 1 allocated (864 bytes), 1 used, 1 users [SHARED]
6:   - Pool requri (1024 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
6:   - Pool buffer (16416 bytes) : 2 allocated (32832 bytes), 2 used, 1 users [SHARED]
6: Total: 10 pools, 37344 bytes allocated, 37344 used.
6: 
```

With nbprocs < 2

```
[root@6c7b51b85ac6 source]# ./haproxyctl show info -p1
/source/bin/../lib/haproxyctl.rb:94:in `unixsock': Could not find a stats socket with process 1 in /etc/haproxy/haproxy.cfg (RuntimeError)
    from ./haproxyctl:195
[root@6c7b51b85ac6 source]# ./haproxyctl show info -p0
Name: HAProxy
Version: 1.5.2
Release_date: 2014/07/12
Nbproc: 1
Process_num: 1
Pid: 23
Uptime: 0d 0h13m33s
Uptime_sec: 813
Memmax_MB: 0
Ulimit-n: 8036
Maxsock: 8036
Maxconn: 4000
Hard_maxconn: 4000
CurrConns: 0
CumConns: 4
CumReq: 4
MaxSslConns: 0
CurrSslConns: 0
CumSslConns: 0
Maxpipes: 0
PipesUsed: 0
PipesFree: 0
ConnRate: 0
ConnRateLimit: 0
MaxConnRate: 0
SessRate: 0
SessRateLimit: 0
MaxSessRate: 0
SslRate: 0
SslRateLimit: 0
MaxSslRate: 0
SslFrontendKeyRate: 0
SslFrontendMaxKeyRate: 0
SslFrontendSessionReuse_pct: 0
SslBackendKeyRate: 0
SslBackendMaxKeyRate: 0
SslCacheLookups: 0
SslCacheMisses: 0
CompressBpsIn: 0
CompressBpsOut: 0
CompressBpsRateLim: 0
ZlibMemUsage: 0
MaxZlibMemUsage: 0
Tasks: 11
Run_queue: 1
Idle_pct: 100
node: 6c7b51b85ac6
description: 

# Without the -p parameter as well when nbprocs < 2
[root@bcdb5ee693d1 source]# ./haproxyctl show pools
Dumping pools usage. Use SIGQUIT to flush them.
  - Pool pipe (32 bytes) : 5 allocated (160 bytes), 5 used, 3 users [SHARED]
  - Pool capture (64 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
  - Pool channel (80 bytes) : 2 allocated (160 bytes), 2 used, 1 users [SHARED]
  - Pool task (112 bytes) : 11 allocated (1232 bytes), 11 used, 1 users [SHARED]
  - Pool uniqueid (128 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
  - Pool connection (320 bytes) : 2 allocated (640 bytes), 2 used, 1 users [SHARED]
  - Pool hdr_idx (416 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
  - Pool session (864 bytes) : 1 allocated (864 bytes), 1 used, 1 users [SHARED]
  - Pool requri (1024 bytes) : 0 allocated (0 bytes), 0 used, 1 users [SHARED]
  - Pool buffer (16416 bytes) : 2 allocated (32832 bytes), 2 used, 1 users [SHARED]
Total: 10 pools, 35888 bytes allocated, 35888 used.
```

```
[root@1cfa2370b6cf source]# ./haproxyctl -p4 set weight backend/node01 40

[root@1cfa2370b6cf source]# ./haproxyctl -p0 get weight backend/node01 
1: 60 (initial 60)
1: 
2: 60 (initial 60)
2: 
3: 60 (initial 60)
3: 
4: 40 (initial 60)
4: 
5: 60 (initial 60)
5: 
6: 60 (initial 60)
6: 
```
