### PR TITLE
Fix status support on FreeBSD/OpenBSD

### DIFF
--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -79,7 +79,7 @@ module HAProxyCTL
       end
 
       # verify these pid(s) exists and are haproxy
-      if pids and pids.all? { |pid| pid =~ /^\d+$/ and `ps -p #{pid} -o cmd=` =~ /#{exec}/ }
+      if pids and pids.all? { |pid| pid =~ /^\d+$/ and `ps -p #{pid} -o command=` =~ /#{exec}/ }
         return pids
       end
     end


### PR DESCRIPTION
When we run "ps -o cmd=" on BSD hosts we get:

ps: cmd: keyword not found
ps: no valid keywords; valid keywords:

Using "command=" is supported on BSD/Linux
"cmd=" is an alias of "command=" on Linux.
