### PR TITLE
Multi-process support, drain commands, etc...

### DIFF
--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -124,7 +124,7 @@ begin
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
-        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] == 'UP')
+        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/)
           unixsock("disable server #{data[0]}/#{data[1]}", process)
         end
       end
@@ -135,7 +135,7 @@ begin
     status = unixsock('show stat', process)
     status.each do |line|
       data = line.split(',')
-      if  ( data[1] == servername) && ( data[17] == 'UP')
+      if  ( data[1] == servername)
         unixsock("disable server #{data[0]}/#{servername}", process)
       end
     end
@@ -148,7 +148,7 @@ begin
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
-        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] =~ /Down|MAINT/i)
+        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/)
           unixsock("enable server #{data[0]}/#{data[1]}", process)
         end
       end
@@ -175,7 +175,7 @@ begin
     status = unixsock('show stat', process)
     status.each do |line|
       data = line.split(',')
-      if  ( data[1] == servername) && ( data[17] =~ /DOWN|MAINT|DRAIN/i)
+      if  ( data[1] == servername)
         unixsock("enable server #{data[0]}/#{servername}", process)
       end
     end
@@ -185,7 +185,7 @@ begin
     status = unixsock('show stat', process)
     status.each do |line|
       data = line.split(',')
-      if  ( data[1] == servername) && ( data[17] == 'UP')
+      if  ( data[1] == servername)
         unixsock("set server #{data[0]}/#{servername} state drain", process)
       end
     end
@@ -198,7 +198,7 @@ begin
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
-        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] == 'UP')
+        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/)
           unixsock("set server #{data[0]}/#{data[1]} state drain", process)
         end
       end

--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -53,8 +53,16 @@ begin
       start
     end
   when 'reload'
-    if  pidof
+    if pidof
       reload(pidof)
+    else
+      puts 'haproxy not running.  starting...'
+      start
+    end
+  when /reload_kill_zombies\s(\d+)/
+    if pidof
+      seconds_to_wait = Regexp.last_match[1].to_i
+      reload_kill_zombies(pidof, seconds_to_wait)
     else
       puts 'haproxy not running.  starting...'
       start

--- a/bin/haproxyctl
+++ b/bin/haproxyctl
@@ -101,56 +101,62 @@ begin
     # else
     #   puts 'status err haproxy is not running!'
     # end
-  when 'show health'
-    status = unixsock('show stat')
+  when /(\d\s)?show health/
+    process = Regexp.last_match[1].to_i
+    status = unixsock('show stat', process)
     status.each do |line|
       data = line.split(',')
       printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
     end
-  when /show backend(s?)/
-    status = unixsock('show stat').grep(/BACKEND/)
+  when /(\d\s)?show backends?/
+    process = Regexp.last_match[1].to_i
+    status = unixsock('show stat', process).grep(/BACKEND/)
     status.each do |line|
       data = line.split(',')
       printf "%-30s %-30s %-7s %3s\n", data[0], data[1], data[17], data[18]
     end
-  when /disable all EXCEPT (.+)/
-    servername = Regexp.last_match[ 1]
-    status = unixsock('show stat')
+  when /(\d\s)?disable all EXCEPT (.+)/
+    process = Regexp.last_match[1].to_i
+    servername = Regexp.last_match[2]
+    status = unixsock('show stat', process)
     backend = status.grep(/#{servername}/)
     backend.each do |line|
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
         if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] == 'UP')
-          unixsock("disable server #{data[0]}/#{data[1]}")
+          unixsock("disable server #{data[0]}/#{data[1]}", process)
         end
       end
     end
-  when /disable all (.+)/
-    servername = Regexp.last_match[ 1]
-    status = unixsock('show stat')
+  when /(\d\s)?disable all (.+)/
+    process = Regexp.last_match[1].to_i
+    servername = Regexp.last_match[2]
+    status = unixsock('show stat', process)
     status.each do |line|
       data = line.split(',')
       if  ( data[1] == servername) && ( data[17] == 'UP')
-        unixsock("disable server #{data[0]}/#{servername}")
+        unixsock("disable server #{data[0]}/#{servername}", process)
       end
     end
-  when /enable all EXCEPT (.+)/
-    servername = Regexp.last_match[ 1]
-    status = unixsock('show stat')
+  when /(\d\s)?enable all EXCEPT (.+)/
+    process = Regexp.last_match[1].to_i
+    servername = Regexp.last_match[2]
+    status = unixsock('show stat', process)
     backend = status.grep(/#{servername}/)
     backend.each do |line|
       backend_group = line.split(',')
       status.each do |pool|
         data = pool.split(',')
         if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] =~ /Down|MAINT/i)
-          unixsock("enable server #{data[0]}/#{data[1]}")
+          unixsock("enable server #{data[0]}/#{data[1]}", process)
         end
       end
     end
-  when /show stat (.+)/
-    fieldnames = Regexp.last_match[ 1]
-    status = unixsock('show stat')
+  when /(\d\s)?show stat (.+)/
+    process = Regexp.last_match[1].to_i
+    fieldnames = Regexp.last_match[2]
+    status = unixsock('show stat', process)
     indices = fieldnames.split(' ').map do |name|
       status.first.split(',').index(name) || begin
         $stderr.puts("no such field: #{name}")
@@ -163,19 +169,50 @@ begin
       filtered = indices.map { |index| row[index] }
       puts (row[0...2] + filtered).compact.join(',')
     end
-  when /enable all (.+)/
-    servername = Regexp.last_match[ 1]
-    status = unixsock('show stat')
+  when /(\d\s)?enable all (.+)/
+    process = Regexp.last_match[1].to_i
+    servername = Regexp.last_match[2]
+    status = unixsock('show stat', process)
     status.each do |line|
       data = line.split(',')
-      if  ( data[1] == servername) && ( data[17] =~ /Down|MAINT/i)
-        unixsock("enable server #{data[0]}/#{servername}")
+      if  ( data[1] == servername) && ( data[17] =~ /DOWN|MAINT|DRAIN/i)
+        unixsock("enable server #{data[0]}/#{servername}", process)
+      end
+    end
+  when /(\d\s)?drain all (.+)/
+    process = Regexp.last_match[1].to_i
+    servername = Regexp.last_match[2]
+    status = unixsock('show stat', process)
+    status.each do |line|
+      data = line.split(',')
+      if  ( data[1] == servername) && ( data[17] == 'UP')
+        unixsock("set server #{data[0]}/#{servername} state drain", process)
+      end
+    end
+  when /(\d\s)?drain all EXCEPT (.+)/
+    process = Regexp.last_match[1].to_i
+    servername = Regexp.last_match[2]
+    status = unixsock('show stat', process)
+    backend = status.grep(/#{servername}/)
+    backend.each do |line|
+      backend_group = line.split(',')
+      status.each do |pool|
+        data = pool.split(',')
+        if  (data[0] == backend_group[0]) && ( data[1] !~ /#{servername}|BACKEND|FRONTEND/) && ( data[17] == 'UP')
+          unixsock("set server #{data[0]}/#{data[1]} state drain", process)
+        end
       end
     end
   when 'version'
     version
+  when /(\d\s)?(.*)/
+    process = Regexp.last_match[1].to_i
+    command = Regexp.last_match[2]
+    puts unixsock(command, process)
   else
-    puts unixsock(argument)
+    # this case shouldn't be reached due to the
+    # above regex, but leaving it here just in case
+    puts unixsock(argument, nil)
   end
 rescue Errno::ENOENT => e
   STDERR.puts e

--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -47,6 +47,47 @@ module HAProxyCTL
     end
   end
 
+  def reload_kill_zombies(pids, seconds_to_wait)
+    if pids
+      pids_string = pids.join(' ')
+      puts "gracefully stopping connections on pids #{pids_string}..."
+      system("#{exec} -D -f #{config_path} -p #{pidfile} -sf #{pids_string}")
+      puts "checking if connections still alive on #{pids_string}..."
+      nowpids = check_running
+      while pids == nowpids
+        puts "still haven't killed old pids.
+                            waiting 2s for existing connections to die...
+                            (ctrl+c to stop this check)"
+        sleep 2
+        nowpids = check_running || 0
+      end
+      puts "reloaded haproxy on pids #{nowpids.join(', ')}"
+      puts "ensuring that old pids aren't zombies"
+      seconds_waited = 0
+      termed = false
+      while any_running pids
+        if seconds_waited > seconds_to_wait
+          puts "waited #{seconds_waited} for old pids to exit.
+                            they did not die gracefully.
+                            terminating #{pids_string}"
+          if termed
+            puts "SIGTERM didn't work, killing #{pids_string}"
+            system("kill -9 #{pids_string} 2> /dev/null")
+          else
+            system("kill #{pids_string} 2> /dev/null")
+            termed = true
+          end
+        else
+          puts "old pids still alive.
+                            waiting 2s and checking again"
+          sleep 2
+        end
+      end
+    else
+      puts 'haproxy is not running!'
+    end
+  end
+
   def unixsock(command, process)
     output = []
     runs = 0

--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -47,16 +47,16 @@ module HAProxyCTL
     end
   end
 
-  def unixsock(command)
+  def unixsock(command, process)
     output = []
     runs = 0
 
     begin
-      ctl = UNIXSocket.open(socket)
+      ctl = UNIXSocket.open(socket(process))
       if ctl
         ctl.write "#{command}\r\n"
       else
-        puts "cannot talk to #{socket}"
+        puts "cannot talk to #{socket(process)}"
       end
     rescue Errno::EPIPE
       ctl.close
@@ -65,7 +65,7 @@ module HAProxyCTL
       if  runs < 4
         retry
       else
-        puts "the unix socket at #{socket} closed before we could complete this request"
+        puts "the unix socket at #{socket(process)} closed before we could complete this request"
         exit
       end
     end
@@ -88,34 +88,39 @@ module HAProxyCTL
     <<-USAGE
 usage: #{$PROGRAM_NAME} <argument>
   where <argument> can be:
-    start                       : start haproxy unless it is already running
-    stop                        : stop an existing haproxy
-    restart                     : immediately shutdown and restart
-    reload                      : gracefully terminate existing connections, reload #{config_path}
-    status                      : is haproxy running?  on what ports per lsof?
-    configcheck                 : check #{config_path}
-    nagios                      : nagios-friendly status for running process and listener
-    cloudkick                   : cloudkick.com-friendly status and metric for connected users
-    show health                 : show status of all frontends and backend servers
-    show backends               : show status of backend pools of servers
-    enable all <server>         : re-enable a server previously in maint mode on multiple backends
-    disable all <server>        : disable a server from every backend it exists
-    enable all EXCEPT <server>  : like 'enable all', but re-enables every backend except for <server>
-    disable all EXCEPT <server> : like 'disable all', but disables every backend except for <server>
-    clear counters              : clear max statistics counters (add 'all' for all counters)
-    help                        : this message
-    prompt                      : toggle interactive mode with prompt
-    quit                        : disconnect
-    show info                   : report information about the running process
-    show stat                   : report counters for each proxy and server
-    show errors                 : report last request and response errors for each proxy
-    show sess [id]              : report the list of current sessions or dump this session
-    get weight                  : report a server's current weight
-    set weight                  : change a server's weight
-    set timeout                 : change a timeout setting
-    disable server              : set a server in maintenance mode
-    enable server               : re-enable a server that was previously in maintenance mode
-    version                     : version of this script
+    start                               : start haproxy unless it is already running
+    stop                                : stop an existing haproxy
+    restart                             : immediately shutdown and restart
+    reload                              : gracefully terminate existing connections, reload #{config_path}
+    status                              : is haproxy running?  on what ports per lsof?
+    configcheck                         : check #{config_path}
+    nagios                              : nagios-friendly status for running process and listener
+    <proc?> show health                 : show status of all frontends and backend servers
+    <proc?> show backends               : show status of backend pools of servers
+    <proc?> enable all <server>         : re-enable a server previously in maint mode on multiple backends
+    <proc?> disable all <server>        : disable a server from every backend it exists
+    <proc?> drain all <server>          : drain a server from every backend it exists
+    <proc?> enable all EXCEPT <server>  : like 'enable all', but re-enables every backend except for <server>
+    <proc?> disable all EXCEPT <server> : like 'disable all', but disables every backend except for <server>
+    <proc?> drain all EXCEPT <server>   : like 'drain all', but drains every backend except for <server>
+    <proc?> clear counters              : clear max statistics counters (add 'all' for all counters)
+    help                                : this message
+    prompt                              : toggle interactive mode with prompt
+    quit                                : disconnect
+    <proc?> show info                   : report information about the running process
+    <proc?> show stat                   : report counters for each proxy and server
+    <proc?> show errors                 : report last request and response errors for each proxy
+    <proc?> show sess [id]              : report the list of current sessions or dump this session
+    <proc?> get weight                  : report a server's current weight
+    <proc?> set weight                  : change a server's weight
+    <proc?> set timeout                 : change a timeout setting
+    <proc?> disable server              : set a server in maintenance mode
+    <proc?> enable server               : re-enable a server that was previously in maintenance mode
+    version                             : version of this script
+
+  <proc?> is an optional numerical argument that selects the process number to target
+    - only applicable when nbproc > 1
+    - defaults to 1
 USAGE
   end
 end

--- a/lib/haproxyctl.rb
+++ b/lib/haproxyctl.rb
@@ -81,6 +81,7 @@ module HAProxyCTL
           puts "old pids still alive.
                             waiting 2s and checking again"
           sleep 2
+          seconds_waited = seconds_waited + 2
         end
       end
     else

--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -43,14 +43,15 @@ module HAProxyCTL
       end
     end
 
-    def socket
-      @socket ||= begin
-        # If the haproxy config is using nbproc > 1, we assume that all cores
-        # except for 1 do not need commands sent to their sockets (if they exist).
-        # This is a poor assumption, so TODO: improve CLI to accept argument for
-        # processes to target.
+    def socket(process = 1)
+      process = 1 if process == 0
+      @sockets ||= []
+      @sockets[process] ||= begin
+        # If the haproxy config is using nbproc > 1, we pick which socket to use based
+        # on the stats socket process assignment. We expect each stats socket to be
+        # assigned to a single process (we don't support ranges even though haproxy does).
         if nbproc > 1
-          config.match /stats\s+socket \s*([^\s]*) \s*.*process \s*1[\d^]?/
+          config.match /stats\s+socket \s*([^\s]*) \s*.*process \s*#{process}[\d^]?/
         else
           config.match /stats\s+socket \s*([^\s]*)/
         end

--- a/lib/haproxyctl/environment.rb
+++ b/lib/haproxyctl/environment.rb
@@ -85,5 +85,10 @@ module HAProxyCTL
       end
     end
     alias_method :pidof, :check_running
+
+    def any_running(pids)
+      return false if !pids || pids.empty?
+      pids.any? { |pid| pid =~ /^\d+$/ and `ps -p #{pid} -o cmd=` =~ /#{exec}/ }
+    end
   end
 end


### PR DESCRIPTION
- Most commands now accept an optional process number as the first argument, (e.g. haproxyctl 2 enable all myserver, where 2 is the process number to target).
- Assumes all stats sockets are assigned an individual process number (ranges not supported).
- Defaults to process number 1 if nbproc < 2 OR the process number is not provided in the arguments.
- Removed state restrictions on enable/disable/drain commands.  They don't appear to be needed.
- Updated help text
- Added `drain all` commands similar to the existing enable/disable all commands.  These commands put servers in a drain state, which is useful for performing rolling deployments.
